### PR TITLE
chore: codex harness 산출물 gitignore 규칙 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ dist/
 output/backups/
 output/embeddings/
 !output/prompts/
+
+# Codex harness projection artifacts
+.agents/
+.codex/
+AGENTS.md
+AGENTS.override.md


### PR DESCRIPTION
## 배경
Codex harness 동기화 작업은 `.agents/`, `.codex/`, `AGENTS.md` 계열 산출물을 생성하지만, 기존에는 글로벌 gitignore에만 의존하고 있었습니다.

이번 변경은 해당 작업을 **main 기준 별도 브랜치**에서 분리해 진행하고, 저장소 단위에서도 산출물을 명시적으로 ignore 하도록 정리한 것입니다.

## 변경 사항
- `.gitignore`에 Codex harness 산출물 ignore 규칙 추가
  - `.agents/`
  - `.codex/`
  - `AGENTS.md`
  - `AGENTS.override.md`

## 작업 메모
- 브랜치는 `origin/main` 기준으로 생성했습니다.
- 동기화는 `syncing-codex-harness` 스킬 절차로 재실행해 확인했습니다.

## 기대 효과
- 글로벌 gitignore 설정 유무와 무관하게, 팀/CI 환경에서 하니스 산출물이 실수로 추적되지 않음
- Codex 하니스 동기화 작업을 기능 변경과 분리해 관리 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude additional development artifacts and configuration files from version control. This improves repository cleanliness by preventing unnecessary files from being tracked in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->