### PR TITLE
chore: add chrome-devtools MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add project-scoped MCP config file `.mcp.json`
- register `chrome-devtools` server via stdio using `npx -y chrome-devtools-mcp@latest`

## Verification
- `claude mcp list` shows `chrome-devtools` as connected
- `codex mcp list` shows `chrome-devtools` as enabled
- codex global config has `[mcp_servers.chrome-devtools]` in `~/.codex/config.toml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration to support enhanced development tools integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->