### PR TITLE
feat: split 적용 후 sync 트리거 + 동기화 상태 UI

### DIFF
--- a/packages/web/src/components/SyncStatusBadge.tsx
+++ b/packages/web/src/components/SyncStatusBadge.tsx
@@ -1,0 +1,40 @@
+import { AlertTriangle, CheckCircle2, Clock3 } from "lucide-react";
+import type { SyncStatusState } from "../lib/sync-status";
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return "기록 없음";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "기록 없음";
+  return date.toLocaleString("ko-KR", { hour12: false });
+}
+
+export function SyncStatusBadge({
+  status,
+}: {
+  status: SyncStatusState | null;
+}) {
+  if (!status) {
+    return (
+      <div className="inline-flex items-center gap-2 rounded-md border border-slate-300 bg-slate-50 px-3 py-1.5 text-xs text-slate-700">
+        <Clock3 className="h-3.5 w-3.5" />
+        동기화 기록 없음
+      </div>
+    );
+  }
+
+  if (status.hasPendingChanges) {
+    return (
+      <div className="inline-flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs text-amber-900">
+        <AlertTriangle className="h-3.5 w-3.5" />
+        미동기화 변경 있음 · 마지막 성공 {formatTimestamp(status.lastSuccessAt)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-md border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs text-emerald-900">
+      <CheckCircle2 className="h-3.5 w-3.5" />
+      마지막 동기화 {formatTimestamp(status.lastSuccessAt)}
+    </div>
+  );
+}

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -89,6 +89,11 @@ export interface SplitApplyResult {
   splitType?: "hard" | "soft";
   mainNoteId: number;
   newNoteIds: number[];
+  syncResult?: {
+    success: boolean;
+    syncedAt?: string;
+    error?: string;
+  };
   warning?: string;
 }
 

--- a/packages/web/src/lib/sync-status.test.js
+++ b/packages/web/src/lib/sync-status.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  readSyncStatus,
+  recordSyncAttempt,
+  SYNC_STATUS_STORAGE_KEY,
+} from "./sync-status";
+
+class MemoryStorage {
+  constructor() {
+    this.store = new Map();
+  }
+
+  get length() {
+    return this.store.size;
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+
+  key(index) {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+
+  removeItem(key) {
+    this.store.delete(key);
+  }
+
+  setItem(key, value) {
+    this.store.set(key, value);
+  }
+}
+
+describe("sync-status", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: new MemoryStorage(),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  test("records successful sync", () => {
+    const state = recordSyncAttempt({
+      success: true,
+      syncedAt: "2026-02-21T12:34:56.000Z",
+    });
+
+    expect(state.hasPendingChanges).toBe(false);
+    expect(state.lastSuccessAt).toBe("2026-02-21T12:34:56.000Z");
+    expect(state.lastError).toBeNull();
+  });
+
+  test("keeps last success when sync fails", () => {
+    recordSyncAttempt({
+      success: true,
+      syncedAt: "2026-02-21T12:34:56.000Z",
+    });
+    const failed = recordSyncAttempt({
+      success: false,
+      error: "sync: auth not configured",
+    });
+
+    expect(failed.hasPendingChanges).toBe(true);
+    expect(failed.lastSuccessAt).toBe("2026-02-21T12:34:56.000Z");
+    expect(failed.lastError).toContain("auth not configured");
+  });
+
+  test("returns null for malformed payload", () => {
+    localStorage.setItem(SYNC_STATUS_STORAGE_KEY, "{broken");
+    expect(readSyncStatus()).toBeNull();
+  });
+});

--- a/packages/web/src/lib/sync-status.ts
+++ b/packages/web/src/lib/sync-status.ts
@@ -1,0 +1,69 @@
+export const SYNC_STATUS_STORAGE_KEY = "anki_sync_status_v1";
+export const SYNC_STATUS_EVENT = "anki-sync-status-updated";
+
+export interface SyncResultPayload {
+  success: boolean;
+  syncedAt?: string;
+  error?: string;
+}
+
+export interface SyncStatusState {
+  lastAttemptAt: string;
+  lastSuccessAt: string | null;
+  hasPendingChanges: boolean;
+  lastError: string | null;
+}
+
+function emitSyncStatusUpdated(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(SYNC_STATUS_EVENT));
+  }
+}
+
+export function readSyncStatus(): SyncStatusState | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(SYNC_STATUS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SyncStatusState;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (typeof parsed.lastAttemptAt !== "string") return null;
+    if (
+      parsed.lastSuccessAt !== null &&
+      typeof parsed.lastSuccessAt !== "string"
+    ) {
+      return null;
+    }
+    if (typeof parsed.hasPendingChanges !== "boolean") return null;
+    if (parsed.lastError !== null && typeof parsed.lastError !== "string") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSyncStatus(state: SyncStatusState): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(SYNC_STATUS_STORAGE_KEY, JSON.stringify(state));
+  emitSyncStatusUpdated();
+}
+
+export function recordSyncAttempt(result?: SyncResultPayload): SyncStatusState {
+  const now = new Date().toISOString();
+  const previous = readSyncStatus();
+
+  const next: SyncStatusState = {
+    lastAttemptAt: now,
+    lastSuccessAt:
+      result?.success === true
+        ? result.syncedAt || now
+        : previous?.lastSuccessAt || null,
+    hasPendingChanges: result?.success !== true,
+    lastError: result?.success === true ? null : result?.error || "unknown",
+  };
+
+  writeSyncStatus(next);
+  return next;
+}

--- a/packages/web/src/pages/Help.tsx
+++ b/packages/web/src/pages/Help.tsx
@@ -455,7 +455,8 @@ export function Help() {
               <h4 className="font-medium text-sm">분할이 적용되지 않음</h4>
               <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
                 "분할 적용" 버튼을 클릭해야 실제로 적용됩니다. 미리보기만으로는
-                카드가 변경되지 않습니다. 적용 후 Anki에서 동기화하세요.
+                카드가 변경되지 않습니다. 적용 시 자동 동기화를 시도하며,
+                실패하면 경고가 표시됩니다.
               </p>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- split apply 완료 후 `AnkiConnect sync`를 best-effort로 호출
- `/api/split/apply` 응답에 `syncResult` 필드 추가
- sync 실패 시 split 결과는 유지(롤백 없음)
- 대시보드에 `Anki 동기화 상태` 배지 추가
- 웹에서 마지막 sync 시도/성공/에러 상태를 localStorage에 저장 및 표시
- Help 문서 문구를 자동 동기화 동작에 맞게 갱신

## Changed Files
- `packages/server/src/routes/split.ts`
- `packages/web/src/lib/api.ts`
- `packages/web/src/pages/SplitWorkspace.tsx`
- `packages/web/src/pages/Dashboard.tsx`
- `packages/web/src/components/SyncStatusBadge.tsx`
- `packages/web/src/lib/sync-status.ts`
- `packages/web/src/lib/sync-status.test.js`
- `packages/web/src/pages/Help.tsx`

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization with Anki server after applying split operations
  * Added sync status badge on dashboard displaying last synchronization time and pending changes status

* **Improvements**
  * Enhanced user feedback with clear messaging when synchronization succeeds or fails

* **Documentation**
  * Updated help section to reflect automatic sync behavior after split application

* **Tests**
  * Added tests for sync status tracking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->