### PR TITLE
chore(web): apply nitpick follow-ups for sync status UX/tests

### DIFF
--- a/packages/web/src/components/SyncStatusBadge.tsx
+++ b/packages/web/src/components/SyncStatusBadge.tsx
@@ -26,7 +26,9 @@ export function SyncStatusBadge({
     return (
       <div className="inline-flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs text-amber-900">
         <AlertTriangle className="h-3.5 w-3.5" />
-        미동기화 변경 있음 · 마지막 성공 {formatTimestamp(status.lastSuccessAt)}
+        미동기화 변경 있음
+        {status.lastSuccessAt &&
+          ` · 마지막 성공 ${formatTimestamp(status.lastSuccessAt)}`}
       </div>
     );
   }

--- a/packages/web/src/lib/sync-status.test.js
+++ b/packages/web/src/lib/sync-status.test.js
@@ -70,6 +70,19 @@ describe("sync-status", () => {
     expect(failed.lastError).toContain("auth not configured");
   });
 
+  test("records fallback state when sync result is missing", () => {
+    const state = recordSyncAttempt();
+
+    expect(state.hasPendingChanges).toBe(true);
+    expect(state.lastSuccessAt).toBeNull();
+    expect(state.lastError).toBe("unknown");
+
+    const persisted = readSyncStatus();
+    expect(persisted).not.toBeNull();
+    expect(persisted?.hasPendingChanges).toBe(true);
+    expect(persisted?.lastError).toBe("unknown");
+  });
+
   test("returns null for malformed payload", () => {
     localStorage.setItem(SYNC_STATUS_STORAGE_KEY, "{broken");
     expect(readSyncStatus()).toBeNull();


### PR DESCRIPTION
## Summary
Follow-up for nitpick comments from PR #25 review (`#pullrequestreview-3835477488`).

### Applied
- `packages/web/src/components/SyncStatusBadge.tsx`
  - when `hasPendingChanges === true` and `lastSuccessAt === null`, do not render awkward
    "마지막 성공 기록 없음" text
  - now renders:
    - `미동기화 변경 있음`
    - adds ` · 마지막 성공 ...` only when `lastSuccessAt` exists

- `packages/web/src/lib/sync-status.test.js`
  - added test for `recordSyncAttempt()` with missing result payload
  - verifies fallback state (`hasPendingChanges: true`, `lastError: "unknown"`, `lastSuccessAt: null`) and persistence

### Not applied (with reason)
- `packages/server/src/routes/split.ts` sync timeout wrapper suggestion
  - current `sync()` path already uses bounded timeout via core client:
    - `packages/core/src/anki/client.ts`: `AbortSignal.timeout(timeoutMs)`
    - default timeout: `5000ms`
  - so there is no indefinite blocking in current implementation.

## Validation
- `bun run --cwd packages/web lint`
- `bun run --cwd packages/web typecheck`
- `bun run --cwd packages/web test`
