### PR TITLE
refactor(web): fix misleading biome-ignore comments in ContentRenderer

### DIFF
--- a/packages/web/src/components/card/ContentRenderer.tsx
+++ b/packages/web/src/components/card/ContentRenderer.tsx
@@ -73,7 +73,7 @@ export function ContentRenderer({
         ) : (
           <div
             className="prose prose-sm dark:prose-invert max-w-none content-rendered"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized HTML rendering from markdown-it
+            // biome-ignore lint/security/noDangerouslySetInnerHtml: Anki card HTML from user's own local database via AnkiConnect; html:true passthrough is intentional for KaTeX/MathML fidelity
             dangerouslySetInnerHTML={{ __html: processedContent }}
           />
         )}
@@ -98,7 +98,7 @@ export function ContentPreview({
         "prose prose-sm dark:prose-invert max-w-none content-rendered",
         className,
       )}
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized HTML rendering from markdown-it
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: Anki card HTML from user's own local database via AnkiConnect; html:true passthrough is intentional for KaTeX/MathML fidelity
       dangerouslySetInnerHTML={{ __html: processedContent }}
     />
   );


### PR DESCRIPTION
## Summary
- `ContentRenderer.tsx`의 biome-ignore 주석이 "sanitized HTML rendering from markdown-it"이라고 기술하고 있었으나, markdown-it `html: true`는 sanitization을 수행하지 않음
- 주석을 실제 동작에 맞게 수정하여 코드 정직성(code honesty) 확보

## Test plan
- [x] `bun run lint:web` 통과
- [x] `bun run typecheck:web` 통과
- [x] 기능적 변경 없음 — 주석만 수정

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code documentation to clarify how HTML content is rendered with support for mathematical notation preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->