### PR TITLE
fix(devShell): worktree 복귀 후 lefthook core.hooksPath 충돌 해결

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,9 @@
         ];
 
         shellHook = ''
+          # worktree 환경에서 공유 config에 남은 core.hooksPath를 정리
+          # (lefthook 2.x는 core.hooksPath가 설정되어 있으면 install을 거부함)
+          git config --unset-all --local core.hooksPath 2>/dev/null || true
           lefthook install
         '';
       };


### PR DESCRIPTION
## Summary

- Claude Code `--worktree` 사용 시 worktree와 메인 레포가 `.git/config`를 공유하므로, worktree 내 `lefthook install`이 기록한 `core.hooksPath`가 메인 워크트리 복귀 시 충돌을 일으키는 문제 해결
- `shellHook`에서 `lefthook install` 전에 `git config --unset-all --local core.hooksPath`를 실행하여 lefthook 2.x의 설치 거부를 방지
- nixos-config에서 동일 이슈를 해결한 [greenheadHQ/nixos-config#99](https://github.com/greenheadHQ/nixos-config/pull/99)와 같은 접근

## 원인 분석

1. `c --worktree`가 `.claude/worktrees/<name>/`에 git worktree 생성
2. worktree와 메인 레포가 **동일한** `.git/config` 파일을 공유
3. worktree의 devShell 진입 시 `lefthook install`이 `core.hooksPath`를 `.git/config`에 기록
4. 메인 워크트리 복귀 후 `lefthook install` 재실행 시 이미 설정된 `core.hooksPath`와 충돌 → lefthook 2.x가 설치 거부

## 검토된 대안

| 대안 | 판단 |
|------|------|
| `lefthook install --reset-hooks-path` | **기각** — global `core.hooksPath`까지 삭제하는 부작용 |
| `lefthook install --force` | **기각** — `core.hooksPath`가 설정된 채로 진행, 후속 문제 발생 가능 |
| `extensions.worktreeConfig` (per-worktree config) | **기각** — 이 이슈에 비해 과도한 변경 |
| `git config --unset-all --local core.hooksPath` | **채택** — local scope만 정리, global 미영향, 미설정 시 no-op |

## Test plan

- [ ] `nix develop` 또는 `direnv allow`로 devShell 진입 시 lefthook 에러 없이 정상 설치 확인
- [ ] `c --worktree` 후 worktree 진입/복귀 반복 시 에러 미발생 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to improve compatibility with Lefthook 2.x during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->