### PR TITLE
fix(web): bun 네이티브 러너 false failure 해결

### DIFF
--- a/packages/web/bunfig.toml
+++ b/packages/web/bunfig.toml
@@ -1,0 +1,8 @@
+[test]
+# packages/web의 테스트 러너 구성:
+#   bun test     → src/ 내 bun:test 네이티브 테스트만 실행
+#   bun run test → vitest (tests/components/**)
+#   bun run test:e2e → playwright (tests/e2e/**)
+# tests/ 디렉토리의 vitest/playwright 테스트가 bun 네이티브 러너에 감지되지 않도록
+# root를 src/로 제한한다.
+root = "src"


### PR DESCRIPTION
## Summary

- `packages/web/bunfig.toml` 생성: `[test] root = "src"` 설정으로 bun 네이티브 러너의 테스트 탐색 범위를 `src/`로 제한
- vitest/playwright 테스트가 bun 네이티브 러너에 감지되어 발생하던 5 fail + 1 error 해소

## Before / After

| 명령 | Before | After |
|------|--------|-------|
| `cd packages/web && bun test` | 7 pass + 5 fail + 1 error (exit 1) | 4 pass + 0 fail (exit 0) |
| `cd packages/web && bun run test` | vitest 7/7 pass | 변경 없음 |
| 루트 `bun run test` | 97 pass | 변경 없음 |

## Test plan

- [x] `cd packages/web && bun test` → 4 pass, 0 fail, exit 0
- [x] `cd packages/web && bun run test` → vitest 7/7 pass
- [x] 루트 `bun run test` → core 81 + server 9 + web 7 = 97 pass

Closes #46