### PR TITLE
fix(web): 태블릿 반응형 레이아웃 개선 — 콘텐츠 멀티컬럼 xl 상향

### DIFF
--- a/packages/web/src/pages/CardBrowser.tsx
+++ b/packages/web/src/pages/CardBrowser.tsx
@@ -558,7 +558,7 @@ export function CardBrowser() {
                     <TableRow>
                       <TableHead>카드</TableHead>
                       <TableHead>검증</TableHead>
-                      <TableHead className="hidden md:table-cell">Cloze</TableHead>
+                      <TableHead className="hidden xl:table-cell">Cloze</TableHead>
                       <TableHead>분할</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -581,7 +581,7 @@ export function CardBrowser() {
                         <TableCell>
                           <ValidationIcon status={validationStatuses.get(card.noteId) || null} />
                         </TableCell>
-                        <TableCell className="hidden md:table-cell text-xs">
+                        <TableCell className="hidden xl:table-cell text-xs">
                           {card.clozeStats.totalClozes}
                         </TableCell>
                         <TableCell>

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -110,7 +110,7 @@ export function Dashboard() {
 
       {/* Stats Grid */}
       {selectedDeck && (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 xl:grid-cols-3">
           <Card>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 p-3 pb-2">
               <CardTitle className="text-sm font-medium">총 노트</CardTitle>

--- a/packages/web/src/pages/Help.tsx
+++ b/packages/web/src/pages/Help.tsx
@@ -91,7 +91,7 @@ export function Help() {
       {/* 기능별 가이드 */}
       <section id="features">
         <h2 className="typo-h2 mb-4">기능별 가이드</h2>
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4 xl:grid-cols-2">
           {/* Dashboard */}
           <Card>
             <CardHeader className="pb-2">

--- a/packages/web/src/pages/PromptManager.tsx
+++ b/packages/web/src/pages/PromptManager.tsx
@@ -54,7 +54,7 @@ type TabType = "versions" | "experiments" | "metrics";
 
 export function PromptManager() {
   const queryClient = useQueryClient();
-  const isMobile = useIsMobile("md");
+  const isMobile = useIsMobile("xl");
   const [activeTab, setActiveTab] = useState<TabType>("versions");
   const [selectedVersion, setSelectedVersion] = useState<PromptVersion | null>(null);
   const [systemPromptDraft, setSystemPromptDraft] = useState("");
@@ -300,14 +300,14 @@ export function PromptManager() {
       )}
 
       {/* 탭 네비게이션 — 모바일에서 sticky */}
-      <div className="flex mb-4 sticky top-14 z-10 bg-background md:static md:z-auto">
+      <div className="flex mb-4 sticky top-14 z-10 bg-background xl:static xl:z-auto">
         {tabs.map((tab) => (
           <button
             type="button"
             key={tab.id}
             onClick={() => setActiveTab(tab.id)}
             className={cn(
-              "flex items-center justify-center gap-1.5 flex-1 min-w-0 px-2 md:px-4 py-2.5 border-b-2 transition-all duration-200",
+              "flex items-center justify-center gap-1.5 flex-1 min-w-0 px-2 xl:px-4 py-2.5 border-b-2 transition-all duration-200",
               activeTab === tab.id
                 ? "border-primary text-primary"
                 : "border-border text-muted-foreground hover:text-foreground",
@@ -511,7 +511,7 @@ function SystemPromptEditor({
               <AlertTriangle className="w-4 h-4" />
               CAS 충돌 발생: 원격 revision {conflictLatest.revision}
             </div>
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
               <div className="space-y-1">
                 <p className="text-xs font-medium text-muted-foreground flex items-center gap-1">
                   <GitCompareArrows className="w-3.5 h-3.5" />
@@ -579,12 +579,12 @@ function VersionsTab({
   const showDetail = !!selectedVersion;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-12 gap-4 h-full grid-rows-[1fr] overflow-hidden">
+    <div className="grid grid-cols-1 xl:grid-cols-12 gap-4 h-full grid-rows-[1fr] overflow-hidden">
       {/* 버전 목록 — 모바일: 상세 선택 시 숨김 */}
       <div
         className={cn(
-          "md:col-span-5 overflow-y-auto min-h-0 min-w-0",
-          showDetail && "hidden md:block",
+          "xl:col-span-5 overflow-y-auto min-h-0 min-w-0",
+          showDetail && "hidden xl:block",
         )}
       >
         <Card className="h-full">
@@ -637,7 +637,7 @@ function VersionsTab({
       </div>
 
       {/* 버전 상세 — 모바일: 전체 너비, 뒤로 버튼 */}
-      <div className={cn("md:col-span-7 min-h-0 min-w-0", !showDetail && "hidden md:block")}>
+      <div className={cn("xl:col-span-7 min-h-0 min-w-0", !showDetail && "hidden xl:block")}>
         {selectedVersion ? (
           <Card className="h-full flex flex-col overflow-hidden">
             <CardHeader className="py-3 px-4 border-b flex flex-row items-center justify-between shrink-0">
@@ -646,7 +646,7 @@ function VersionsTab({
                   variant="ghost"
                   size="sm"
                   onClick={() => onSelectVersion(null)}
-                  className="md:hidden px-0"
+                  className="xl:hidden px-0"
                 >
                   <ChevronLeft className="w-4 h-4" />
                   뒤로
@@ -897,7 +897,7 @@ function MetricsTab({ versions }: MetricsTabProps) {
           <CardTitle className="text-sm">전체 통계</CardTitle>
         </CardHeader>
         <CardContent className="px-4">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-4">
+          <div className="grid grid-cols-2 xl:grid-cols-4 gap-2 xl:gap-4">
             <MetricCard label="총 분할 수" value={totalSplits} />
             <MetricCard
               label="평균 승인률"
@@ -925,13 +925,13 @@ function MetricsTab({ versions }: MetricsTabProps) {
                   <TableHead className="text-left px-4 py-2">버전</TableHead>
                   <TableHead className="text-right px-4 py-2">분할 수</TableHead>
                   <TableHead className="text-right px-4 py-2">승인률</TableHead>
-                  <TableHead className="hidden md:table-cell text-right px-4 py-2">
+                  <TableHead className="hidden xl:table-cell text-right px-4 py-2">
                     수정률
                   </TableHead>
-                  <TableHead className="hidden md:table-cell text-right px-4 py-2">
+                  <TableHead className="hidden xl:table-cell text-right px-4 py-2">
                     거부율
                   </TableHead>
-                  <TableHead className="hidden md:table-cell text-right px-4 py-2">
+                  <TableHead className="hidden xl:table-cell text-right px-4 py-2">
                     평균 글자
                   </TableHead>
                 </TableRow>
@@ -953,13 +953,13 @@ function MetricsTab({ versions }: MetricsTabProps) {
                         {Math.round((version.metrics?.approvalRate || 0) * 100)}%
                       </span>
                     </TableCell>
-                    <TableCell className="hidden md:table-cell px-4 py-2 text-right text-yellow-600">
+                    <TableCell className="hidden xl:table-cell px-4 py-2 text-right text-yellow-600">
                       {Math.round((version.metrics?.modificationRate || 0) * 100)}%
                     </TableCell>
-                    <TableCell className="hidden md:table-cell px-4 py-2 text-right text-red-600">
+                    <TableCell className="hidden xl:table-cell px-4 py-2 text-right text-red-600">
                       {Math.round((version.metrics?.rejectionRate || 0) * 100)}%
                     </TableCell>
-                    <TableCell className="hidden md:table-cell px-4 py-2 text-right">
+                    <TableCell className="hidden xl:table-cell px-4 py-2 text-right">
                       {Math.round(version.metrics?.avgCharCount || 0)}
                     </TableCell>
                   </TableRow>

--- a/packages/web/src/pages/SplitHistory.tsx
+++ b/packages/web/src/pages/SplitHistory.tsx
@@ -650,10 +650,10 @@ export function SplitHistory() {
                     <TableRow>
                       <TableHead>Note</TableHead>
                       <TableHead>상태</TableHead>
-                      <TableHead className="hidden md:table-cell">모델</TableHead>
-                      <TableHead className="hidden md:table-cell">카드수</TableHead>
-                      <TableHead className="hidden lg:table-cell">비용</TableHead>
-                      <TableHead className="hidden md:table-cell">생성일시</TableHead>
+                      <TableHead className="hidden xl:table-cell">모델</TableHead>
+                      <TableHead className="hidden xl:table-cell">카드수</TableHead>
+                      <TableHead className="hidden xl:table-cell">비용</TableHead>
+                      <TableHead className="hidden xl:table-cell">생성일시</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -675,20 +675,20 @@ export function SplitHistory() {
                         <TableCell>
                           <StatusBadge status={item.status} />
                         </TableCell>
-                        <TableCell className="hidden md:table-cell">
+                        <TableCell className="hidden xl:table-cell">
                           {item.provider ? (
                             <ModelBadge provider={item.provider} />
                           ) : (
                             <span className="text-xs text-muted-foreground">--</span>
                           )}
                         </TableCell>
-                        <TableCell className="hidden md:table-cell text-xs">
+                        <TableCell className="hidden xl:table-cell text-xs">
                           {item.cardCount}
                         </TableCell>
-                        <TableCell className="hidden lg:table-cell text-xs font-mono text-muted-foreground">
+                        <TableCell className="hidden xl:table-cell text-xs font-mono text-muted-foreground">
                           {item.actualCostUsd != null ? formatCostUsd(item.actualCostUsd) : "--"}
                         </TableCell>
-                        <TableCell className="hidden md:table-cell text-xs text-muted-foreground">
+                        <TableCell className="hidden xl:table-cell text-xs text-muted-foreground">
                           {new Date(item.createdAt).toLocaleString()}
                         </TableCell>
                       </TableRow>

--- a/packages/web/src/pages/SplitWorkspace.tsx
+++ b/packages/web/src/pages/SplitWorkspace.tsx
@@ -232,7 +232,7 @@ function RejectPopover({
 }
 
 export function SplitWorkspace() {
-  const isMobile = useIsMobile("lg");
+  const isMobile = useIsMobile("xl");
 
   const [selectedDeck, setSelectedDeck] = useState<string | null>(null);
   const [selectedCard, setSelectedCard] = useState<SplitCandidate | null>(null);
@@ -908,7 +908,7 @@ export function SplitWorkspace() {
 
   // 높이: 모바일/태블릿 dvh-5rem (h-14 헤더 + p-3 x2), 데스크톱(lg) vh-4rem (p-6 x2)
   return (
-    <div className="h-[calc(100dvh-5rem)] lg:h-[calc(100vh-4rem)] flex flex-col">
+    <div className="h-[calc(100dvh-5rem)] md:h-[calc(100vh-4rem)] flex flex-col">
       {/* ===== 모바일 헤더 (< lg) ===== */}
       {isMobile ? (
         <div className="flex flex-col gap-3 overflow-hidden">


### PR DESCRIPTION
## Summary

태블릿(768px~1279px)에서 사이드바(256px)가 표시되면 콘텐츠 영역이 512~1023px로 줄어드는데, 멀티컬럼 레이아웃이 `md`/`lg`에서 활성화되어 콘텐츠가 과도하게 좁아지는 문제 수정.

- **FRAME-level** (`md:` 유지): 사이드바 토글, 모바일 헤더 숨김, 컨테이너 패딩
- **CONTENT-level** (`xl:`로 상향): 페이지 그리드, 테이블 컬럼, 뒤로가기 버튼 등

### 변경 파일 (6개, 순수 Tailwind 클래스 변경)

| 파일 | 변경 내용 |
|------|-----------|
| `SplitWorkspace.tsx` | `useIsMobile` lg→xl, 높이 계산 lg→md |
| `PromptManager.tsx` | `useIsMobile` md→xl, 버전 그리드/탭/메트릭 테이블 md→xl |
| `Dashboard.tsx` | 통계 그리드 md+lg→xl |
| `SplitHistory.tsx` | 테이블 컬럼 md/lg→xl |
| `CardBrowser.tsx` | Cloze 컬럼 md→xl |
| `Help.tsx` | 가이드 그리드 md→xl |

## Before / After (Tablet 1024px)

<details>
<summary><strong>Prompts 페이지</strong> (가장 큰 변화)</summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-prompts-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-prompts-tablet.png) |

</details>

<details>
<summary><strong>Help 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-help-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-help-tablet.png) |

</details>

<details>
<summary><strong>Split 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-split-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-split-tablet.png) |

</details>

<details>
<summary><strong>History 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-history-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-history-tablet.png) |

</details>

<details>
<summary><strong>Browse 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-browse-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-browse-tablet.png) |

</details>

<details>
<summary><strong>Dashboard 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-dashboard-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-dashboard-tablet.png) |

</details>

<details>
<summary><strong>Backups 페이지</strong></summary>

| Before | After |
|:---:|:---:|
| ![before](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/before-backups-tablet.png) | ![after](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-backups-tablet.png) |

</details>

## Desktop (1280px) — 멀티컬럼 정상 동작 확인

<details>
<summary><strong>Prompts 데스크톱</strong></summary>

![prompts-desktop](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-prompts-desktop.png)

</details>

<details>
<summary><strong>Split 데스크톱</strong></summary>

![split-desktop](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-split-desktop.png)

</details>

<details>
<summary><strong>전체 데스크톱 스크린샷</strong></summary>

| 페이지 | 스크린샷 |
|--------|----------|
| Dashboard | ![](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-dashboard-desktop.png) |
| Browse | ![](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-browse-desktop.png) |
| History | ![](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-history-desktop.png) |
| Backups | ![](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-backups-desktop.png) |
| Help | ![](https://github.com/greenheadHQ/awesome-anki/releases/download/untagged-fe3f6ab8aebe63703094/after-help-desktop.png) |

</details>

## Test plan

- [x] lint/typecheck/test 통과 (pre-push hook)
- [x] 1024px 태블릿: 사이드바 + 모바일 스타일 콘텐츠
- [x] 1280px 데스크톱: 사이드바 + 멀티컬럼 정상 활성화
- [ ] PromptManager: 태블릿에서 버전 선택 → 뒤로 버튼 → 목록 복귀 확인
- [ ] BottomSheet: Split 설정, Browse/History 필터 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive layout breakpoints across multiple pages to optimize how content displays on different screen sizes.
  * Adjusted table column visibility and grid layouts to improve presentation on mobile, tablet, and desktop devices.
  * Refined header positioning and navigation elements for better usability across viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->