### PR TITLE
fix(query-keys): byDeck opts에 누락된 limit 타입 추가

### DIFF
--- a/.claude/skills/developing-web-ui/references/query-patterns.md
+++ b/.claude/skills/developing-web-ui/references/query-patterns.md
@@ -10,7 +10,7 @@ export const queryKeys = {
 
   cards: {
     all: ["cards"] as const,
-    byDeck: (deck: string, opts?: { page?: number; filter?: string }) =>
+    byDeck: (deck: string, opts?: { page?: number; limit?: number; filter?: string }) =>
       ["cards", "deck", deck, opts] as const,
     detail: (noteId: number) => ["cards", "detail", noteId] as const,
     difficult: (deck: string, opts?: { page?: number; limit?: number }) =>

--- a/packages/web/src/lib/query-keys.ts
+++ b/packages/web/src/lib/query-keys.ts
@@ -4,7 +4,7 @@ export const queryKeys = {
 
   cards: {
     all: ["cards"] as const,
-    byDeck: (deck: string, opts?: { page?: number; filter?: string }) =>
+    byDeck: (deck: string, opts?: { page?: number; limit?: number; filter?: string }) =>
       ["cards", "deck", deck, opts] as const,
     detail: (noteId: number) => ["cards", "detail", noteId] as const,
     difficult: (deck: string, opts?: { page?: number; limit?: number }) =>


### PR DESCRIPTION
## Summary

- `queryKeys.cards.byDeck` opts 타입에 누락된 `limit?: number` 추가
- 소비자 `useCards` 훅과의 타입 일관성 복원
- 형제 키 `difficult`과의 일관성 확보
- 대응 스킬 문서(`query-patterns.md`) 동기화

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced deck card queries to support an optional limit parameter, allowing control over the number of results returned when filtering cards by deck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->