### PR TITLE
fix(web): SplitWorkspace versionId 차원 누락 — 프롬프트 버전 전환 시 stale preview·상태 leak

### DIFF
--- a/packages/web/src/pages/SplitWorkspace.tsx
+++ b/packages/web/src/pages/SplitWorkspace.tsx
@@ -302,6 +302,7 @@ export function SplitWorkspace() {
   const mutationMatchesCurrent =
     splitPreview.data &&
     splitPreview.variables?.noteId === selectedCard?.noteId &&
+    splitPreview.variables?.versionId === (activeVersionId || undefined) &&
     splitPreview.variables?.provider === activeProvider &&
     splitPreview.variables?.model === activeModel;
   const previewData: SplitPreviewResult | undefined =
@@ -311,11 +312,12 @@ export function SplitWorkspace() {
   const isLoadingCurrentCard =
     splitPreview.isPending &&
     splitPreview.variables?.noteId === selectedCard?.noteId &&
+    splitPreview.variables?.versionId === (activeVersionId || undefined) &&
     splitPreview.variables?.provider === activeProvider &&
     splitPreview.variables?.model === activeModel;
 
   // 현재 선택된 카드+모델의 에러 메시지 확인
-  const analysisKey = (nid: number) => `${nid}:${activeProvider}/${activeModel}`;
+  const analysisKey = (nid: number) => `${nid}:${activeVersionId || "default"}:${activeProvider}/${activeModel}`;
   const currentCardError = selectedCard
     ? errorAnalyses.get(analysisKey(selectedCard.noteId))
     : undefined;
@@ -797,6 +799,7 @@ export function SplitWorkspace() {
           </div>
         ) : splitPreview.isError &&
           splitPreview.variables?.noteId === selectedCard.noteId &&
+          splitPreview.variables?.versionId === (activeVersionId || undefined) &&
           splitPreview.variables?.provider === activeProvider &&
           splitPreview.variables?.model === activeModel ? (
           <div className="flex flex-col items-center justify-center h-full text-destructive">


### PR DESCRIPTION
## Summary

Closes #73

- `mutationMatchesCurrent`, `isLoadingCurrentCard`, `analysisKey`, 에러 표시 JSX 4개 지점에서 `versionId` 비교/포함 누락 수정
- 같은 카드·모델에서 프롬프트 버전만 전환했을 때 이전 버전의 결과가 현재로 잘못 표시되고, 에러/로딩 상태가 버전 간 leak되는 버그 해결
- `getCachedSplitPreview`·mutation 호출·query key는 이미 `versionId`를 포함하므로, 상태 추적 경로만 일관성 복원

## Test plan

- [x] `bun run --cwd packages/web build` 통과
- [x] `bun run --cwd packages/web test` 통과
- [x] 전체 quality-gate (lint + typecheck + test) 통과
- [ ] 프롬프트 버전 A → B 전환 시 미리보기 빈 상태 확인
- [ ] 버전 전환 후 "적용" 버튼 비활성화 확인
- [ ] 버전 A 에러 → 버전 B 전환 시 에러 UI 미표시 확인
- [ ] 버전 A pending → 버전 B 전환 시 새 요청 가능 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version-specific handling in split preview analyses to ensure accurate state and error tracking when working with multiple versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->