### PR TITLE
fix(core): Clinic 팩트 체크 아이콘/상태 판정 버그 수정

### DIFF
--- a/packages/core/src/validator/fact-checker.ts
+++ b/packages/core/src/validator/fact-checker.ts
@@ -84,9 +84,7 @@ ${cleanContent}
       }) => ({
         claim: c.claim || "",
         isVerified:
-          c.correction != null && c.correction.trim() !== ""
-            ? false
-            : (c.isVerified ?? true),
+          c.correction != null && c.correction.trim() !== "" ? false : (c.isVerified ?? true),
         confidence: c.confidence ?? 50,
         correction: c.correction,
         source: c.source,
@@ -110,8 +108,7 @@ ${cleanContent}
     return {
       status,
       type: "fact-check",
-      message:
-        parsed.summary || getStatusMessage(status, overallAccuracy, hasInaccurateClaims),
+      message: parsed.summary || getStatusMessage(status, overallAccuracy, hasInaccurateClaims),
       confidence: overallAccuracy,
       details: {
         claims,
@@ -139,11 +136,7 @@ ${cleanContent}
   }
 }
 
-function getStatusMessage(
-  status: string,
-  accuracy: number,
-  hasInaccurateClaims: boolean,
-): string {
+function getStatusMessage(status: string, accuracy: number, hasInaccurateClaims: boolean): string {
   switch (status) {
     case "valid":
       return `내용이 정확합니다 (정확도: ${accuracy}%)`;
@@ -152,7 +145,7 @@ function getStatusMessage(
         ? `부정확한 내용 발견 (정확도: ${accuracy}%)`
         : `일부 내용 검증 필요 (정확도: ${accuracy}%)`;
     case "error":
-      return `부정확한 내용 발견 (정확도: ${accuracy}%)`;
+      return `내용 대부분이 부정확합니다 (정확도: ${accuracy}%)`;
     default:
       return "검증 불가";
   }


### PR DESCRIPTION
## Summary

- Clinic 탭 팩트 체크에서 부정확한 항목에 체크(✓) 아이콘 대신 X 아이콘이 정상 표시되도록 수정
- 부정확 항목이 1개라도 있으면 섹션 상태를 최소 "warning"으로 판정
- overallAccuracy를 LLM 반환값 대신 isVerified 비율로 항상 재계산

## 기존 문제/배경

Clinic 탭의 팩트 체크 결과에서 두 가지 버그가 존재했다:

**버그 A — 아이콘 오표시**: LLM이 `isVerified` 필드를 누락하면 기본값 `true`로 처리되어, `correction`이 있는(=부정확한) 항목에도 체크(✓) 아이콘이 표시됨.

**버그 B — 섹션 상태 false negative**: LLM이 반환한 `overallAccuracy`를 그대로 신뢰하여 `isVerified`와 불일치하거나, 정확도 80% 이상이면 부정확 항목이 있어도 "valid"(통과)로 판정됨.

## CIR (Change Intent Record)

- **발견 경위**: 사용자가 Clinic 탭에서 팩트 체크 결과를 확인하던 중 아이콘 표시 이상 발견
- **설계 의도**: correction이 존재하면 해당 항목은 논리적으로 부정확하므로 `isVerified=false`로 강제. overallAccuracy는 단일 소스(isVerified)에서 파생하여 일관성 보장.
- **DA 피드백**: for_plan에서 빈 문자열 방어(CORRECTNESS-1), 프롬프트-파싱 계약 불일치(REGRESSION-001), confidence/status 모순(REGRESSION-002) 지적 → 전부 반영

## ADR (Architecture Decision Record)

| 대안 | 설명 | 장점 | 단점 | 결정 |
|------|------|------|------|------|
| correction 존재 시 isVerified=false 강제 | correction이 있으면 무조건 부정확 처리 | 논리적 일관성, LLM 불확실성 방어 | LLM이 의도적으로 correction+verified 조합을 반환하는 케이스 무시 | ✅ |
| isVerified 기본값을 false로 변경 | 불확실한 항목을 모두 부정확 처리 | 보수적 | LLM이 정상 반환해도 모두 부정확 표시 | ❌ |
| LLM overallAccuracy 우선 사용 (현행 유지) | LLM의 종합 판단 존중 | LLM 판단 활용 | isVerified와 불일치 가능, 신뢰성 낮음 | ❌ |

## 구현 상세

| 파일 | 변경 내용 |
|------|----------|
| `packages/core/src/validator/fact-checker.ts` | isVerified 기본값 수정, overallAccuracy 재계산, 상태 판정 조건 추가, 프롬프트 정리, 메시지 분기 |

### 핵심 변경

```typescript
// 1. correction 존재 시 isVerified=false 강제 (빈 문자열 방어)
isVerified: c.correction != null && c.correction.trim() !== ""
  ? false : (c.isVerified ?? true),

// 2. overallAccuracy 항상 재계산 (LLM 반환값 무시)
const overallAccuracy = claims.length > 0
  ? Math.round((claims.filter(c => c.isVerified).length / claims.length) * 100)
  : 100;

// 3. 부정확 항목 1개라도 있으면 최소 warning
const hasInaccurateClaims = claims.some(c => !c.isVerified);
if (overallAccuracy < 80 || hasInaccurateClaims) status = "warning";
```

## 참고 레퍼런스

- `e69e8cf` — feat(web): Clinic 탭 Phase 2 (팩트 체크 UI 도입)
- `21795aa` — feat(web): Validate 탭 Phase 1 (5종 검증 허브)

## Human Test Plan

1. `bun run dev` 실행
2. Clinic 탭에서 팩트 체크 실행 (또는 기존 캐시된 카드에서 "재검증" 클릭)
3. **아이콘 확인**: correction이 있는 항목에 X(빨간) 아이콘이 표시되는지 확인
4. **섹션 상태 확인**: 부정확 항목이 1개라도 있으면 팩트 체크 섹션이 "경고"(노란 삼각형)로 표시되는지 확인
5. **메시지 확인**: warning 시 "부정확한 내용 발견 (정확도: N%)", error 시 "내용 대부분이 부정확합니다 (정확도: N%)"가 표시되는지 확인

## Pre-Merge E2E 테스트 가이드

### Phase 0: 정적 검증

```bash
# isVerified 기본값이 correction 체크로 변경되었는지
grep -n "c.correction != null" packages/core/src/validator/fact-checker.ts

# overallAccuracy에서 parsed.overallAccuracy가 제거되었는지
grep -c "parsed.overallAccuracy" packages/core/src/validator/fact-checker.ts
# 기대: 0

# hasInaccurateClaims 변수가 존재하는지
grep -n "hasInaccurateClaims" packages/core/src/validator/fact-checker.ts

# 프롬프트에서 overallAccuracy가 제거되었는지
grep -c "overallAccuracy" packages/core/src/validator/fact-checker.ts
# 기대: overallAccuracy는 계산 변수로만 존재, 프롬프트에는 없음
```

### Phase 1: 빌드 검증

```bash
bun run build    # 타입 에러 없이 성공
bun run test     # 전체 테스트 통과
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fact-checking accuracy calculation based on verified claims.
  * Enhanced warning alerts to flag content with unverified or inaccurate claims.
  * Clarified messaging to better communicate detected inaccuracies in content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->